### PR TITLE
Add GitHub Actions test status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 A comprehensive whiskey collection management application built with TypeScript, React, Express, and SQLite. Track your whiskey collection with detailed information, pricing, tasting notes, inventory management, and investment tracking.
 
+[![Tests](https://github.com/DamageLabs/whiskey-canon/actions/workflows/test.yml/badge.svg)](https://github.com/DamageLabs/whiskey-canon/actions/workflows/test.yml)
 ![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?style=flat&logo=typescript&logoColor=white)
 ![React](https://img.shields.io/badge/React-20232A?style=flat&logo=react&logoColor=61DAFB)
 ![Express](https://img.shields.io/badge/Express.js-404D59?style=flat&logo=express)


### PR DESCRIPTION
## Summary
- Add test workflow status badge to README for CI visibility
- Badge links to GitHub Actions workflow page

## Test plan
- [x] Verify badge renders correctly on GitHub
- [x] Verify badge shows correct pass/fail status
- [x] Verify badge links to workflow page