### PR TITLE
Add Codecov coverage badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A comprehensive whiskey collection management application built with TypeScript, React, Express, and SQLite. Track your whiskey collection with detailed information, pricing, tasting notes, inventory management, and investment tracking.
 
 [![Tests](https://github.com/DamageLabs/whiskey-canon/actions/workflows/test.yml/badge.svg)](https://github.com/DamageLabs/whiskey-canon/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/DamageLabs/whiskey-canon/graph/badge.svg)](https://codecov.io/gh/DamageLabs/whiskey-canon)
 ![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?style=flat&logo=typescript&logoColor=white)
 ![React](https://img.shields.io/badge/React-20232A?style=flat&logo=react&logoColor=61DAFB)
 ![Express](https://img.shields.io/badge/Express.js-404D59?style=flat&logo=express)


### PR DESCRIPTION
## Summary
- Add Codecov coverage badge to README
- Badge displays test coverage percentage and links to Codecov dashboard

## Test plan
- [x] Verify badge renders correctly on GitHub
- [x] Verify badge links to Codecov dashboard
- [x] After merge, confirm coverage uploads on next workflow run