### PR TITLE
Add proof field to whiskey UI components

### DIFF
--- a/backend/src/models/Whiskey.test.ts
+++ b/backend/src/models/Whiskey.test.ts
@@ -38,6 +38,7 @@ describe('WhiskeyModel', () => {
         region: 'Kentucky',
         age: 12,
         abv: 45.0,
+        proof: 90.0,
         size: '750ml',
         quantity: 2,
         msrp: 50.00,
@@ -50,6 +51,7 @@ describe('WhiskeyModel', () => {
       expect(whiskey.region).toBe('Kentucky');
       expect(whiskey.age).toBe(12);
       expect(whiskey.abv).toBe(45.0);
+      expect(whiskey.proof).toBe(90.0);
       expect(whiskey.size).toBe('750ml');
       expect(whiskey.quantity).toBe(2);
       expect(whiskey.msrp).toBe(50.00);

--- a/frontend/src/components/WhiskeyCard.tsx
+++ b/frontend/src/components/WhiskeyCard.tsx
@@ -43,6 +43,13 @@ export function WhiskeyCard({ whiskey, onEdit, onDelete }: WhiskeyCardProps) {
             </div>
           )}
 
+          {whiskey.proof && (
+            <div className="d-flex justify-content-between border-bottom pb-2 mb-2">
+              <span className="text-muted">Proof:</span>
+              <strong>{whiskey.proof}</strong>
+            </div>
+          )}
+
           {whiskey.size && (
             <div className="d-flex justify-content-between border-bottom pb-2 mb-2">
               <span className="text-muted">Size:</span>

--- a/frontend/src/components/WhiskeyDetailModal.tsx
+++ b/frontend/src/components/WhiskeyDetailModal.tsx
@@ -62,6 +62,15 @@ export function WhiskeyDetailModal({ whiskey, onClose, onEdit, onDelete }: Whisk
                 </div>
               )}
 
+              {whiskey.proof && (
+                <div className="col-md-4">
+                  <div className="border-start border-4 ps-3" style={{ borderColor: 'var(--amber-500)' }}>
+                    <small className="text-muted text-uppercase d-block mb-1">Proof</small>
+                    <strong>{whiskey.proof}</strong>
+                  </div>
+                </div>
+              )}
+
               {whiskey.size && (
                 <div className="col-md-4">
                   <div className="border-start border-4 ps-3" style={{ borderColor: 'var(--amber-500)' }}>

--- a/frontend/src/components/WhiskeyTable.tsx
+++ b/frontend/src/components/WhiskeyTable.tsx
@@ -12,7 +12,7 @@ interface WhiskeyTableProps {
   selectionEnabled?: boolean;
 }
 
-type SortColumn = 'name' | 'type' | 'distillery' | 'region' | 'age' | 'abv' | 'size' | 'quantity' | 'msrp' | 'secondary_price' | 'rating';
+type SortColumn = 'name' | 'type' | 'distillery' | 'region' | 'age' | 'abv' | 'proof' | 'size' | 'quantity' | 'msrp' | 'secondary_price' | 'rating';
 type SortDirection = 'asc' | 'desc';
 
 export function WhiskeyTable({
@@ -131,6 +131,9 @@ export function WhiskeyTable({
             <th onClick={() => handleSort('abv')} style={{ cursor: 'pointer', userSelect: 'none' }}>
               ABV {renderSortIcon('abv')}
             </th>
+            <th onClick={() => handleSort('proof')} style={{ cursor: 'pointer', userSelect: 'none' }}>
+              Proof {renderSortIcon('proof')}
+            </th>
             <th onClick={() => handleSort('size')} style={{ cursor: 'pointer', userSelect: 'none' }}>
               Size {renderSortIcon('size')}
             </th>
@@ -178,6 +181,7 @@ export function WhiskeyTable({
               <td>{whiskey.region || '-'}</td>
               <td>{whiskey.age ? `${whiskey.age} years` : '-'}</td>
               <td>{whiskey.abv ? `${whiskey.abv}%` : '-'}</td>
+              <td>{whiskey.proof || '-'}</td>
               <td>{whiskey.size || '-'}</td>
               <td>{whiskey.quantity || '-'}</td>
               <td>{formatCurrencyOrDash(whiskey.msrp)}</td>


### PR DESCRIPTION
## Summary
- Display proof alongside ABV in WhiskeyCard component
- Display proof in WhiskeyDetailModal
- Add sortable proof column to WhiskeyTable
- Add proof field coverage to Whiskey model test

## Test plan
- [x] Verify proof displays in card view when value exists
- [x] Verify proof displays in detail modal when value exists
- [x] Verify proof column appears in table and is sortable
- [x] Run `npm test` to confirm model tests pass