### PR TITLE
Add historical entries to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,16 +24,102 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Simplified Dashboard bulk actions to only show when items are selected
 - Statistics now update based on filtered results
 
-## [1.0.0] - 2025-01-01
+## [1.0.5] - 2026-02-04
+
+### Added
+
+- Proof field to whiskey UI components (WhiskeyForm, WhiskeyCard, WhiskeyTable, WhiskeyDetailModal)
+- Accounting format for currency display with parentheses for negative values
+- Bulk delete functionality for whiskey collection
+- Tests for auth, admin, and comments routes
+- Tests for User model and whiskey route error handling
+- Tests for profile photo upload and delete routes
+- Codecov coverage badge to README
+- GitHub Actions test status badge to README
+
+### Changed
+
+- Use secondary market prices in collection value calculations
+
+## [1.0.4] - 2026-02-03
+
+### Added
+
+- Nginx reverse proxy configuration with Let's Encrypt SSL support
+- `obtained_from` field to track who gifted a bottle
+- Comments system for whiskeys with full CRUD operations
+- Unit tests for comments and obtained_from field
+
+### Fixed
+
+- Session cookies for production behind Nginx reverse proxy
+- WhiskeyModel.create() to insert all fields from seed data
+
+## [1.0.3] - 2026-02-02
+
+### Added
+
+- Email verification system with 6-digit codes
+- Password reset functionality via email
+- Integration with Resend email service
+- Git workflow rules to CLAUDE.md documentation
+
+## [1.0.2] - 2026-02-01
+
+### Added
+
+- GitHub Actions workflow for automated testing
+- Vitest test infrastructure for backend
+- Comprehensive test coverage for User model
+- Tests for Admin and Statistics routes
+- Tests for RBAC (Role-Based Access Control)
+- Tests for CSV import/export functionality
+- Whiskey model tests with 100% coverage
+- Whiskey routes integration tests
+- Auth middleware and routes tests
+
+### Fixed
+
+- TypeScript compilation errors caught by CI
+- GitHub Actions test-summary job conditional syntax
+
+### Changed
+
+- Improved table row contrast on dashboard for better readability
+
+## [1.0.1] - 2026-01-25
+
+### Added
+
+- New dark UI theme with amber accents
+- Landing page outlining site features
+- OnlyDrams CSV import support (PR #7)
+
+### Changed
+
+- Updated header and footer design
+- Improved registration page styling
+
+## [1.0.0] - 2026-01-20
 
 ### Added
 
 - Initial release of Whiskey Canon
-- User authentication with session-based auth
-- Whiskey collection management (CRUD operations)
-- Dashboard with card and table views
-- Analytics page with charts
+- User authentication with session-based auth and RBAC (admin/editor/viewer roles)
+- Whiskey collection management with full CRUD operations
+- Dashboard with card and table view modes
+- Analytics page with Recharts visualizations
 - Admin panel for user management
 - CSV import/export functionality
 - Profile page with photo upload
-- 57-field whiskey schema with comprehensive tracking
+- 57-field whiskey schema including:
+  - Basic info (name, type, distillery, region, age, ABV)
+  - Purchase tracking (date, price, location)
+  - Inventory management (opened status, remaining volume, storage location)
+  - Cask details (type, finish, barrel/bottle numbers)
+  - Tasting notes (nose, palate, finish, color)
+  - Investment tracking (market value, gain/loss)
+  - Production details (limited edition, chill filtered, natural color)
+- Demo seed data with 6 users and 170 whiskeys
+- WhiskeyStats component with collection statistics
+- EnhancedStats component with detailed analytics


### PR DESCRIPTION
## Summary

- Document all releases from v1.0.0 through v1.0.5 based on git history
- Provides complete project history for reference

## Versions Added

| Version | Date | Highlights |
|---------|------|------------|
| v1.0.5 | 2026-02-04 | Proof field, accounting format, bulk delete |
| v1.0.4 | 2026-02-03 | Nginx config, comments system, obtained_from field |
| v1.0.3 | 2026-02-02 | Email verification and password reset |
| v1.0.2 | 2026-02-01 | GitHub Actions CI and test coverage |
| v1.0.1 | 2026-01-25 | Dark UI theme and landing page |
| v1.0.0 | 2026-01-20 | Initial release |

## Test plan

- [x] CHANGELOG follows Keep a Changelog format
- [x] Dates match git history