### PR TITLE
Fix admin backup restore schema mismatch

### DIFF
--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -398,8 +398,21 @@ router.post(
 
         const restoreTransaction = db.transaction(() => {
           for (const table of tablesToRestore) {
+            // Get columns present in both backup and live table to handle schema differences
+            const backupCols = db
+              .prepare(`PRAGMA backup_db.table_info("${table}")`)
+              .all() as Array<{ name: string }>;
+            const mainCols = db
+              .prepare(`PRAGMA main.table_info("${table}")`)
+              .all() as Array<{ name: string }>;
+            const mainColNames = new Set(mainCols.map((c) => c.name));
+            const commonCols = backupCols.map((c) => c.name).filter((n) => mainColNames.has(n));
+
             db.exec(`DELETE FROM main."${table}"`);
-            db.exec(`INSERT INTO main."${table}" SELECT * FROM backup_db."${table}"`);
+            const colList = commonCols.map((c) => `"${c}"`).join(', ');
+            db.exec(
+              `INSERT INTO main."${table}" (${colList}) SELECT ${colList} FROM backup_db."${table}"`
+            );
           }
         });
 


### PR DESCRIPTION
## Summary
- Fixed admin backup restore failing with `table main.users has 18 columns but 17 values were supplied` when restoring a backup taken before a schema migration
- The restore now introspects both backup and live tables via `PRAGMA table_info` to find common columns, so it works across schema changes

## Test plan
- [x] Create a full admin backup
- [x] Run a schema migration that adds a column
- [x] Restore from the pre-migration backup and verify it succeeds
- [x] Verify data integrity after restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)