### PR TITLE
Fix backup download 500 error

### DIFF
--- a/backend/src/routes/backups.ts
+++ b/backend/src/routes/backups.ts
@@ -14,6 +14,7 @@ import {
   validateAndStoreUpload,
 } from '../services/backup-service';
 import { backupLimiter } from '../middleware/rateLimiter';
+import fs from 'fs';
 
 // Configure multer for JSON backup file uploads
 const backupUpload = multer({
@@ -162,9 +163,12 @@ router.get(
       }
 
       const contentType = record.format === 'json' ? 'application/json' : 'text/csv';
+      const stat = fs.statSync(filePath);
       res.setHeader('Content-Type', contentType);
+      res.setHeader('Content-Length', stat.size);
       res.setHeader('Content-Disposition', `attachment; filename="${record.filename}"`);
-      res.sendFile(filePath);
+      const stream = fs.createReadStream(filePath);
+      stream.pipe(res);
     } catch (error) {
       console.error('Backup download error:', error);
       res.status(500).json({ error: 'Failed to download backup' });

--- a/backend/src/services/backup-service.ts
+++ b/backend/src/services/backup-service.ts
@@ -33,7 +33,7 @@ export interface RestorePreview {
 
 function getBackupDir(): string {
   const backupDir = config.backupDir || path.join(__dirname, '../../backups');
-  return backupDir;
+  return path.resolve(backupDir);
 }
 
 function ensureBackupDir(userId: number): string {


### PR DESCRIPTION
## Summary
- Resolve `getBackupDir()` to an absolute path so file operations don't fail when `BACKUP_DIR` is a relative config value (e.g. `./backups`)
- Replace `res.sendFile()` with `fs.createReadStream().pipe(res)` for more reliable file streaming
- Add `Content-Length` header for proper download progress

## Test plan
- [x] Create a backup from the profile page
- [x] Download the backup and verify the file is valid JSON
- [x] Verify backup restore still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)