### PR TITLE
Add hourly backup schedule option

### DIFF
--- a/backend/src/models/BackupSchedule.ts
+++ b/backend/src/models/BackupSchedule.ts
@@ -67,6 +67,10 @@ export class BackupScheduleModel {
   private static calculateNextRun(interval: string): string | null {
     const now = new Date();
     switch (interval) {
+      case 'hourly':
+        now.setMinutes(0, 0, 0);
+        now.setHours(now.getHours() + 1);
+        break;
       case 'daily':
         now.setDate(now.getDate() + 1);
         break;

--- a/backend/src/routes/backups.ts
+++ b/backend/src/routes/backups.ts
@@ -123,8 +123,8 @@ router.put(
   '/schedule',
   [
     body('interval')
-      .isIn(['disabled', 'daily', 'weekly', 'monthly'])
-      .withMessage('Interval must be disabled, daily, weekly, or monthly'),
+      .isIn(['disabled', 'hourly', 'daily', 'weekly', 'monthly'])
+      .withMessage('Interval must be disabled, hourly, daily, weekly, or monthly'),
     body('format').isIn(['json', 'csv']).withMessage('Format must be json or csv'),
     body('retentionDays')
       .isInt({ min: 1, max: 365 })

--- a/frontend/src/components/BackupManager.tsx
+++ b/frontend/src/components/BackupManager.tsx
@@ -296,6 +296,7 @@ export function BackupManager() {
               }}
             >
               <option value="disabled">Disabled</option>
+              <option value="hourly">Hourly</option>
               <option value="daily">Daily</option>
               <option value="weekly">Weekly</option>
               <option value="monthly">Monthly</option>


### PR DESCRIPTION
## Summary
- Add "hourly" as a valid backup schedule interval
- Align hourly `next_run_at` to the top of the hour to prevent clock drift causing backups to run every 2 hours instead of every 1 hour
- Add "Hourly" option to the backup frequency dropdown in the UI

## Test plan
- [x] Set backup schedule to "Hourly" from Profile page and save
- [x] Verify backups are created every hour (check at :00 marks)
- [x] Verify other intervals (daily, weekly, monthly, disabled) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)